### PR TITLE
Fix compiles under Ubuntu 18

### DIFF
--- a/src/addressmode.hpp
+++ b/src/addressmode.hpp
@@ -5,6 +5,7 @@
 
 #include <string>
 #include <utility>
+#include <memory>
 #include <vector>
 
 #include "datatype.hpp"


### PR DESCRIPTION
This fixes compiles under Ubuntu 18 so that mcbasic can be compiled with:
`g++ -std=c++14 *.cpp -o mcbasic`